### PR TITLE
ops: health_sanity Prom query and backup verify in nightly

### DIFF
--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -27,6 +27,20 @@ jobs:
         run: |
           chmod +x scripts/ops/health_sanity.sh || true
           ./scripts/ops/health_sanity.sh || true
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Prometheus Optional Check" >> $GITHUB_STEP_SUMMARY
+          echo "(Resurgent target up% printed when available)" >> $GITHUB_STEP_SUMMARY
+
+      - name: Verify backups (read-only)
+        shell: bash
+        run: |
+          if [ -x scripts/backups/verify_backups.sh ]; then
+            echo "::group::Backup verification (read-only)"
+            scripts/backups/verify_backups.sh --base-dir /home/mills/backup/maelstrom --max-age-days 7 || true
+            echo "::endgroup::"
+          else
+            echo "verify_backups.sh not present; skipping"
+          fi
 
       - name: Emit endpoints reference
         shell: bash
@@ -34,4 +48,3 @@ jobs:
           echo "# Readiness Endpoints" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           sed -n '1,200p' docs/ops/health_check_endpoints.md >> $GITHUB_STEP_SUMMARY
-

--- a/README.md
+++ b/README.md
@@ -11,10 +11,14 @@ Production-grade monitoring and security infrastructure built with Docker Compos
 <!-- STATUS-BEGIN -->
 | Key Metric       | Value             |
 |------------------|------------------|
-| Stack Health     | 🟢 Healthy |
+| Stack Health     | 🟡 Degraded |
 | Critical Alerts  | ✅ None |
-| Failing Services | 0 |
-| Last Check       | 2025-08-09 21:39 UTC |
+| Failing Services | 2 |
+| Last Check       | 2025-08-11 01:26 UTC |
+
+**Failing Services:**
+- trivy (restarting)
+- vault (unhealthy)
 <!-- STATUS-END -->
 
 ## Backups Scope
@@ -92,6 +96,9 @@ cd maelstrom
 
 # Security scan
 ./validate_stack.sh --security-only
+
+# Lightweight, non-destructive sanity
+./scripts/ops/health_sanity.sh
 ```
 
 ## 📊 Service Access Points
@@ -102,6 +109,7 @@ cd maelstrom
 - Config collections: `collections/` (service configs; data dirs use `*-data`).
 - Tests: `tests/unit`, `tests/integration` with pytest markers.
 - Docs: `docs/` (guides, architecture). Contributor info: `AGENTS.md`, `CONTRIBUTING.md`, `SECURITY.md`.
+  - Ops: `docs/ops/health_check_endpoints.md`, `docs/ops/prometheus_rules_layout.md`, `docs/ops/backups.md`.
 - Backups & logs: `backups/`, `logs/`, soft-deletes in `trash/`.
 
 ### Core Dashboards

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1623,7 +1623,17 @@ services:
       - no-new-privileges:true
     logging: *default-logging
     healthcheck:
-      test: ["CMD-SHELL", "python - <<'PY'\nimport sys, urllib.request\ntry:\n    with urllib.request.urlopen('http://localhost:5002/health', timeout=3) as r:\n        sys.exit(0 if r.status==200 else 1)\nexcept Exception:\n    sys.exit(1)\nPY"]
+      test:
+        - CMD-SHELL
+        - |
+          python - <<'PY'
+          import sys, urllib.request
+          try:
+              with urllib.request.urlopen('http://localhost:5002/health', timeout=3) as r:
+                  sys.exit(0 if r.status==200 else 1)
+          except Exception:
+              sys.exit(1)
+          PY
       interval: 30s
       timeout: 10s
       retries: 3
@@ -1660,7 +1670,17 @@ services:
       - no-new-privileges:true
     logging: *default-logging
     healthcheck:
-      test: ["CMD-SHELL", "python - <<'PY'\nimport sys, urllib.request\ntry:\n    with urllib.request.urlopen('http://localhost:5003/health', timeout=3) as r:\n        sys.exit(0 if r.status==200 else 1)\nexcept Exception:\n    sys.exit(1)\nPY"]
+      test:
+        - CMD-SHELL
+        - |
+          python - <<'PY'
+          import sys, urllib.request
+          try:
+              with urllib.request.urlopen('http://localhost:5003/health', timeout=3) as r:
+                  sys.exit(0 if r.status==200 else 1)
+          except Exception:
+              sys.exit(1)
+          PY
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/ops/backups.md
+++ b/docs/ops/backups.md
@@ -1,0 +1,35 @@
+# Backups (Operations)
+
+This project includes backup utilities under `scripts/backups/`. This document outlines read-only verification and a safe approach to scheduling.
+
+## Verify backups (read-only)
+
+Use the verification script to summarize presence and recency without writing:
+
+```bash
+scripts/backups/verify_backups.sh --base-dir /home/mills/backup/maelstrom --max-age-days 7
+```
+
+Outputs recent directories/files, newest artifacts, and totals. It never writes.
+
+## Dry-run utilities
+
+- `scripts/backups/backup_influxdb.sh` — supports dry-run flags in comments; consult script usage.
+- `scripts/backups/backup_volume.sh` — supports `--dry-run`.
+
+## Suggested schedule (example; commented)
+
+Add to crontab (edit with `crontab -e`) only after validation. The following shows a daily verification and weekly dry-run example; both are safe.
+
+```cron
+# Daily verify (07:30): read-only check of backups directory
+30 7 * * * /bin/bash -lc 'cd $HOME && scripts/backups/verify_backups.sh --base-dir /home/mills/backup/maelstrom --max-age-days 7 >> $HOME/tools/duo/logs/backup_verify.log 2>&1'
+
+# Weekly dry-run volume backup sample (Saturday 03:15): adjust volume name
+#15 3 * * 6 /bin/bash -lc 'cd $HOME && scripts/backups/backup_volume.sh prometheus_data --dry-run >> $HOME/tools/duo/logs/backup_dryrun.log 2>&1'
+```
+
+## Retention
+
+Use `scripts/backups/rotate_backups.sh` in `--dry-run` first to preview deletions before enabling in production.
+

--- a/docs/ops/lsyncd_troubleshooting.md
+++ b/docs/ops/lsyncd_troubleshooting.md
@@ -1,0 +1,39 @@
+# Lsyncd Troubleshooting (Maelstrom)
+
+Lsyncd mirrors `/home/mills` content (e.g., ops artifacts) to `/mnt/code`. If the service appears `activating` or lagging, use this read-only flow:
+
+## Read-only checks
+
+```bash
+# Service state and recent logs
+systemctl status codex-home-sync.service --no-pager
+journalctl -u codex-home-sync.service -n 200 --no-pager
+
+# Lsyncd logs (host)
+sudo tail -n 200 /var/log/lsyncd/lsyncd.log
+
+# Target mount posture
+findmnt -no SOURCE,TARGET,OPTIONS /mnt/code
+```
+
+## Common causes
+- Target share latency or reconnects causing startup delays.
+- Exclusion rules causing noisy retries.
+- Permission issues on specific files.
+
+## Low-risk remediation (change window)
+- Restart service after confirming target mount is healthy:
+
+```bash
+sudo systemctl restart codex-home-sync.service
+sleep 5
+systemctl is-active codex-home-sync.service
+```
+
+- If restart keeps reverting to `activating`, increase verbosity and inspect rsync options in the unit configuration (file location may vary) and confirm remote path accessibility.
+
+## Validation
+- Service becomes `active`.
+- Lsyncd log shows steady syncing without repeated backoffs.
+- No errors in `journalctl -u codex-home-sync.service` for 5–10 minutes after restart.
+


### PR DESCRIPTION
Extend health_sanity.sh to print Prometheus resurgent target up% when available (non-blocking).
Add a read-only backup verification step to the nightly health workflow.