### PR TITLE
ops: nightly share scan (read-only) + hygiene issue helper

### DIFF
--- a/.github/workflows/nightly-share-scan.yml
+++ b/.github/workflows/nightly-share-scan.yml
@@ -1,0 +1,27 @@
+name: Nightly Share Scan
+
+on:
+  schedule:
+    - cron: '11 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  share-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run share scan (read-only)
+        shell: bash
+        run: |
+          chmod +x scripts/ops/share_scan.sh || true
+          ./scripts/ops/share_scan.sh || true
+
+      - name: Upload scan artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: share-scan-md
+          path: output/share_scan_*.md
+          if-no-files-found: warn
+

--- a/scripts/ops/create_hygiene_issues.py
+++ b/scripts/ops/create_hygiene_issues.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import os, re, subprocess, json, glob
+
+def run(cmd, input_bytes=None):
+    if input_bytes is not None and isinstance(input_bytes, bytes):
+        cp = subprocess.run(cmd, input=input_bytes, capture_output=True)
+        # decode for consistency
+        cp.stdout = cp.stdout.decode(errors='ignore') if isinstance(cp.stdout, (bytes, bytearray)) else cp.stdout
+        cp.stderr = cp.stderr.decode(errors='ignore') if isinstance(cp.stderr, (bytes, bytearray)) else cp.stderr
+        return cp.returncode, cp.stdout, cp.stderr
+    cp = subprocess.run(cmd, input=input_bytes, capture_output=True, text=True)
+    return cp.returncode, cp.stdout, cp.stderr
+
+def get_owner_repo():
+    rc, out, _ = run(['bash','-lc','git remote get-url origin 2>/dev/null'])
+    m = re.search(r'github.com[:/]+([^/]+/[^/.]+)', out.strip())
+    return m.group(1) if m else ''
+
+def gh_post(url: str, obj: dict):
+    payload = json.dumps(obj).encode()
+    cmd = [ 'bash','-lc', f"./scripts/github_api.sh -X POST '{url}' --data @-" ]
+    rc, out, err = run(cmd, input_bytes=payload)
+    if rc != 0:
+        print('WARN: POST failed', url, err)
+        return {}
+    try:
+        return json.loads(out)
+    except Exception:
+        return {}
+
+def main():
+    owner_repo = get_owner_repo()
+    if not owner_repo:
+        print('No origin repo found; aborting')
+        return
+    files = sorted(glob.glob('/home/mills/tools/duo/logs/resurgent_code_focus_*.md'))
+    if not files:
+        print('No focused scan MD found; aborting')
+        return
+    path = files[-1]
+    text = open(path).read().splitlines()
+    issues = []
+    cur = None
+    data = {}
+    for ln in text:
+        m = re.match(r'^###\s+(\S.*)$', ln)
+        if m:
+            cur = m.group(1).strip()
+            data[cur] = { 'missing': [] }
+            continue
+        if cur:
+            if 'missing' in ln.lower():
+                # e.g., "- README: missing"
+                data[cur]['missing'].append(ln.strip('- ').strip())
+    # Create issues for projects with missing items
+    for proj, d in data.items():
+        missing = [m for m in d['missing'] if 'missing' in m.lower()]
+        if not missing:
+            continue
+        title = f"Hygiene: {proj} — add/normalize: " + ', '.join(sorted(set([m.split(':',1)[0] for m in missing])))
+        body_lines = [f"Source: {path}", '', f"## Missing items for {proj}"]
+        for m in missing:
+            body_lines.append(f"- [ ] {m}")
+        body_lines += ['', '## Suggested next steps',
+                       '- Add a minimal README with purpose, setup, and status.',
+                       '- Add tests/CI if repo contains living code.',
+                       '- If this is a sandbox or archive, mark it clearly to avoid confusion.']
+        issue = gh_post(f'https://api.github.com/repos/{owner_repo}/issues',
+                        { 'title': title, 'body': '\n'.join(body_lines), 'labels': ['ops','hygiene'] })
+        if issue.get('html_url'):
+            print('ISSUE', issue['html_url'])
+        else:
+            print('WARN: issue not created for', proj)
+
+if __name__ == '__main__':
+    main()

--- a/scripts/ops/share_scan.sh
+++ b/scripts/ops/share_scan.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only scan of the Resurgent code share for TODO/FIXME/WIP markers
+# and basic project hygiene. Produces a Markdown report.
+#
+# Behavior:
+# - If /mnt/code exists, scans it with exclusions and time bounds.
+# - If not present, produces a short report noting the skip.
+# - Writes report to ./output/share_scan_YYYYmmdd_HHMMSS.md
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+OUTDIR="$ROOT_DIR/output"
+mkdir -p "$OUTDIR"
+TS=$(date +%Y%m%d_%H%M%S)
+OUT="$OUTDIR/share_scan_${TS}.md"
+
+if [ ! -d /mnt/code ]; then
+  {
+    echo "# Resurgent Share Scan (skipped)"
+    echo
+    echo "Generated: $(date -Is)"
+    echo
+    echo "/mnt/code is not mounted on this runner; skipping read-only scan."
+  } > "$OUT"
+  echo "WROTE $OUT"
+  exit 0
+fi
+
+PATTERN='TODO|FIXME|WIP|HACK|BUG|XXX'
+{
+  echo "# Resurgent Share Scan"
+  echo
+  echo "Generated: $(date -Is)"
+  echo
+  echo "Top-level directories under /mnt/code:"
+  echo
+  find /mnt/code -maxdepth 1 -mindepth 1 -type d -printf '- %f\n' 2>/dev/null | sort || true
+  echo
+  echo "## Marker files (TODO*, FIXME*, *TODO*.md)"
+  echo
+  find /mnt/code -maxdepth 3 \
+    \( -iname 'TODO*' -o -iname 'FIXME*' -o -iname '*TODO*.md' \) \
+    -type f -printf '%P\n' 2>/dev/null | sed 's#^#- /mnt/code/#' | head -n 200 || true
+  echo
+  echo "## Code markers (TODO/FIXME/WIP/HACK/BUG/XXX) — sampled"
+  echo
+  if command -v rg >/dev/null 2>&1; then
+    timeout 45 rg -n --no-heading --hidden -S -e "$PATTERN" /mnt/code \
+      -g '!**/.git/**' -g '!**/node_modules/**' -g '!**/dist/**' -g '!**/build/**' \
+      -g '!**/.venv/**' -g '!**/venv/**' -g '!**/__pycache__/**' \
+      -g '!**/logs/**' -g '!**/backups/**' -g '!**/output/**' -g '!**/trash/**' \
+      --max-filesize 512k | sed -E 's#^/mnt/code/##' | head -n 1000 || true
+  else
+    timeout 45 grep -RInE "$PATTERN" /mnt/code \
+      --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=build \
+      --exclude-dir=.venv --exclude-dir=venv --exclude-dir=__pycache__ --exclude-dir=logs \
+      --exclude-dir=backups --exclude-dir=output --exclude-dir=trash --binary-files=without-match 2>/dev/null \
+      | sed -E 's#^/mnt/code/##' | head -n 1000 || true
+  fi
+  echo
+  echo "## Notes"
+  echo "- This is a time-bounded sample (<=45s scan, 1000 matches)."
+  echo "- Excludes heavy dirs: .git, node_modules, dist, build, venvs, caches, logs, backups, output, trash."
+} > "$OUT"
+
+echo "WROTE $OUT"
+


### PR DESCRIPTION
Add a nightly, read-only share scan workflow which uploads a Markdown report. Includes a local script to convert focused scan findings into GitHub issues.