### PR TITLE
ops: expose services on 0.0.0.0 for LAN access

### DIFF
--- a/.github/workflows/nightly-health.yml
+++ b/.github/workflows/nightly-health.yml
@@ -31,6 +31,13 @@ jobs:
           echo "## Prometheus Optional Check" >> $GITHUB_STEP_SUMMARY
           echo "(Resurgent target up% printed when available)" >> $GITHUB_STEP_SUMMARY
 
+      - name: Upload health sanity artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: health-sanity-md
+          path: output/health_sanity_*.md
+          if-no-files-found: warn
+
       - name: Verify backups (read-only)
         shell: bash
         run: |

--- a/base.yml
+++ b/base.yml
@@ -16,7 +16,7 @@ services:
     image: influxdb:${INFLUXDB_TAG:-1.8}
     container_name: influxdb
     ports:
-      - "127.0.0.1:8086:8086"
+      - "0.0.0.0:8086:8086"
     volumes:
       - /home/mills/collections/influxdb:/var/lib/influxdb
     environment:
@@ -47,7 +47,7 @@ services:
     image: grafana/grafana:${GRAFANA_TAG:-latest}
     container_name: grafana
     ports:
-      - "127.0.0.1:3000:3000"
+      - "0.0.0.0:3000:3000"
     volumes:
       - /home/mills/collections/grafana:/var/lib/grafana
     environment:
@@ -103,7 +103,7 @@ services:
       - '--web.route-prefix=/'
       - '--web.enable-admin-api'
     ports:
-      - "127.0.0.1:9090:9090"
+      - "0.0.0.0:9090:9090"
     restart: unless-stopped
     healthcheck:
       # Treat 200 (ready) or 401 (auth enforced) as healthy
@@ -133,7 +133,7 @@ services:
     image: prom/alertmanager:${ALERTMANAGER_TAG:-latest}
     container_name: alertmanager
     ports:
-      - "127.0.0.1:9093:9093"
+      - "0.0.0.0:9093:9093"
     volumes:
       - /home/mills/collections/alertmanager:/etc/alertmanager:ro
       - alertmanager_data:/alertmanager
@@ -212,7 +212,7 @@ services:
     container_name: telegraf
     profiles: [telegraf]
     ports:
-      - "127.0.0.1:9273:9273"
+      - "0.0.0.0:9273:9273"
     volumes:
       - /home/mills/collections/telegraf-config/telegraf.conf:/etc/telegraf/telegraf.conf:ro
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -271,7 +271,7 @@ services:
     image: gcr.io/cadvisor/cadvisor:${CADVISOR_TAG:-latest}
     container_name: cadvisor
     ports:
-      - "127.0.0.1:8081:8080"
+      - "0.0.0.0:8081:8080"
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:rw
@@ -300,7 +300,7 @@ services:
     image: prom/node-exporter:${NODE_EXPORTER_TAG:-latest}
     container_name: node-exporter
     ports:
-      - "127.0.0.1:9100:9100"
+      - "0.0.0.0:9100:9100"
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
@@ -346,7 +346,7 @@ services:
       - '--collect.info_schema.innodb_tablespaces'
       - '--collect.info_schema.innodb_metrics'
     ports:
-      - "127.0.0.1:9104:9104"
+      - "0.0.0.0:9104:9104"
     restart: unless-stopped
     healthcheck:
       # Verify the exporter HTTP endpoint is serving metrics
@@ -383,7 +383,7 @@ services:
     profiles: [networking]
     command: ["--config.file=/etc/blackbox_exporter/blackbox.yml"]
     ports:
-      - "127.0.0.1:9115:9115"
+      - "0.0.0.0:9115:9115"
     volumes:
       - /home/mills/networking/collections/blackbox-config/blackbox.yml:/etc/blackbox_exporter/blackbox.yml:ro
     restart: unless-stopped
@@ -416,7 +416,7 @@ services:
     container_name: snmp-exporter
     profiles: [networking]
     ports:
-      - "127.0.0.1:9116:9116"
+      - "0.0.0.0:9116:9116"
     volumes:
       - /home/mills/networking/collections/snmp:/etc/snmp_exporter:ro
     restart: unless-stopped
@@ -449,7 +449,7 @@ services:
     container_name: loki
     profiles: [logging, security-stack]
     ports:
-      - "127.0.0.1:3100:3100"
+      - "0.0.0.0:3100:3100"
     volumes:
       - /home/mills/collections/loki:/etc/loki
       - loki_data:/tmp/loki
@@ -554,7 +554,7 @@ services:
     container_name: pihole-secondary
     profiles: [networking]
     ports:
-      - "127.0.0.1:8053:80"
+      - "0.0.0.0:8053:80"
       - "53:53/tcp"
       - "53:53/udp"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     image: influxdb:1.8
     container_name: influxdb
     ports:
-      - "127.0.0.1:8086:8086"
+      - "0.0.0.0:8086:8086"
     volumes:
       - /home/mills/collections/influxdb:/var/lib/influxdb
     environment:
@@ -55,7 +55,7 @@ services:
     image: grafana/grafana:latest
     container_name: grafana
     ports:
-      - "127.0.0.1:3000:3000"
+      - "0.0.0.0:3000:3000"
     volumes:
       - /home/mills/collections/grafana:/var/lib/grafana
     environment:
@@ -146,7 +146,7 @@ services:
       - '--storage.tsdb.wal-compression'
       - '--web.config.file=/etc/prometheus/web.yml'
     ports:
-      - "127.0.0.1:9090:9090"
+      - "0.0.0.0:9090:9090"
     restart: unless-stopped
     healthcheck:
       # Test: Check if Prometheus API responds and is ready to serve queries
@@ -423,7 +423,7 @@ services:
     image: prom/node-exporter:latest
     container_name: node-exporter
     ports:
-      - "127.0.0.1:9100:9100"
+      - "0.0.0.0:9100:9100"
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
@@ -459,7 +459,7 @@ services:
       - '--mysqld.address=zabbix-mysql:3306'
       - '--config.my-cnf=/etc/mysql/.my.cnf'
     ports:
-      - "127.0.0.1:9104:9104"
+      - "0.0.0.0:9104:9104"
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
@@ -513,7 +513,7 @@ services:
     image: prom/alertmanager:latest
     container_name: alertmanager
     ports:
-      - "127.0.0.1:9093:9093"
+      - "0.0.0.0:9093:9093"
     volumes:
       - /home/mills/collections/alertmanager:/etc/alertmanager:ro
       - alertmanager_data:/alertmanager
@@ -1501,7 +1501,7 @@ services:
     image: hashicorp/vault:latest
     container_name: vault
     ports:
-      - "127.0.0.1:8200:8200"
+      - "0.0.0.0:8200:8200"
     volumes:
       - /home/mills/collections/vault/vault-config.hcl:/vault/config/vault.hcl:ro
       - vault_data:/vault/data
@@ -1574,7 +1574,7 @@ services:
       dockerfile: Dockerfile
     container_name: maelstrom-api
     ports:
-      - "127.0.0.1:8000:8000"
+      - "0.0.0.0:8000:8000"
     environment:
       - RESURGENT_IP=${RESURGENT_IP}
       - API_USERNAME=maelstrom_admin
@@ -1608,7 +1608,7 @@ services:
     working_dir: /app
     command: bash -c "pip install -r requirements.txt && python autoops_service.py"
     ports:
-      - "127.0.0.1:5002:5002"
+      - "0.0.0.0:5002:5002"
     volumes:
       - /home/mills/collections/autoops:/app
     environment:
@@ -1655,7 +1655,7 @@ services:
     working_dir: /app
     command: bash -c "pip install -r requirements.txt && python threat_orchestrator.py"
     ports:
-      - "127.0.0.1:5003:5003"
+      - "0.0.0.0:5003:5003"
     volumes:
       - /home/mills/collections/threat-orchestrator:/app
     environment:

--- a/prod.yml
+++ b/prod.yml
@@ -138,7 +138,7 @@ services:
     volumes:
       - wazuh_elastic_data:/usr/share/elasticsearch/data
     ports:
-      - "127.0.0.1:9200:9200"
+      - "0.0.0.0:9200:9200"
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
Bind service ports to 0.0.0.0 instead of 127.0.0.1 to allow access from LAN segments (192.168.1.0/24, 192.168.50.0/24, 192.168.30.0/24) including Resurgent host 192.168.1.115.

Validated:
- docker compose config (base+prod): OK
- yamllint: OK